### PR TITLE
Handle different repositories

### DIFF
--- a/funcs.php
+++ b/funcs.php
@@ -46,6 +46,12 @@ function branches(
         $version = preg_replace('#[^0-9\.]#', '', $json->require->{'silverstripe/assets'} ?? '');
         $matchedOnBranchThreeLess = true;
     }
+    if (!$version) {
+        $version = preg_replace('#[^0-9\.]#', '', $json->require->{'cwp/starter-theme'} ?? '');
+        if ($version) {
+            $version += 1;
+        }
+    }
     if (preg_match('#^([0-9]+)+\.?[0-9]*$#', $version, $matches)) {
         $defaultCmsMajor = $matches[1];
         if ($matchedOnBranchThreeLess) {

--- a/funcs.php
+++ b/funcs.php
@@ -1,5 +1,8 @@
 <?php
 
+// This should always match default branch of silverstripe/framework
+const CURRENT_CMS_MAJOR = 5;
+
 function branches(
     string $defaultBranch,
     string $minimumCmsMajor,
@@ -21,7 +24,20 @@ function branches(
     $defaultMajor = $matches[1];
     
     // read __composer.json of the current (default) branch
-    $contents = $composerJson ?: file_get_contents('__composer.json');
+    if ($composerJson) {
+        $contents = $composerJson;
+    } elseif (file_exists('__composer.json')) {
+        $contents = file_get_contents('__composer.json');
+    } else {
+        // respository such as silverstripe/eslint-config or silverstripe/gha-auto-tag
+        // make some fake json so that this branch is treated as though it's latest supported major version
+        $contents = json_encode([
+            'require' => [
+                'silverstripe/framework' => '^' . CURRENT_CMS_MAJOR,
+            ],
+        ], JSON_UNESCAPED_SLASHES);
+    }
+
     $json = json_decode($contents);
     if (is_null($json)) {
         $lastError = json_last_error();

--- a/tests/BranchesTest.php
+++ b/tests/BranchesTest.php
@@ -343,6 +343,38 @@ class BranchesTest extends TestCase
                 ]
                 EOT,
             ],
+            'cwp-watea-theme' => [
+                'expected' => ['3.2', '3', '4.0', '4'],
+                'defaultBranch' => '4',
+                'minimumCmsMajor' => '4',
+                'githubRepository' => 'lorem/ipsum',
+                'composerJson' => <<<EOT
+                {
+                    "require": {
+                        "cwp/starter-theme": "^4"
+                    }
+                }
+                EOT,
+                'branchesJson' => <<<EOT
+                [
+                    {"name": "3"},
+                    {"name": "3.0"},
+                    {"name": "3.1"},
+                    {"name": "3.2"},
+                    {"name": "4"},
+                    {"name": "4.0"}
+                ]
+                EOT,
+                'tagsJson' => <<<EOT
+                [
+                    {"name": "4.0.0"},
+                    {"name": "5.0.9"},
+                    {"name": "3.2.0"},
+                    {"name": "3.1.0"},
+                    {"name": "3.0.0"}
+                ]
+                EOT,
+            ],
         ];
     }
 }

--- a/tests/BranchesTest.php
+++ b/tests/BranchesTest.php
@@ -375,6 +375,32 @@ class BranchesTest extends TestCase
                 ]
                 EOT,
             ],
+            'gha-ci' => [
+                'expected' => ['1.4', '1'],
+                'defaultBranch' => '1',
+                'minimumCmsMajor' => '4',
+                'githubRepository' => 'silverstripe/gha-ci',
+                'composerJson' => '',
+                'branchesJson' => <<<EOT
+                [
+                    {"name": "1"},
+                    {"name": "1.0"},
+                    {"name": "1.1"},
+                    {"name": "1.2"},
+                    {"name": "1.3"},
+                    {"name": "1.4"}
+                ]
+                EOT,
+                'tagsJson' => <<<EOT
+                [
+                    {"name": "1.4.0"},
+                    {"name": "1.3.0"},
+                    {"name": "1.2.0"},
+                    {"name": "1.1.0"},
+                    {"name": "1.0.0"}
+                ]
+                EOT,
+            ],
         ];
     }
 }


### PR DESCRIPTION
There's a couple of commits in here:
- Handle cwp-watea-theme by looking for cwp/starter-theme
- Handle repositories without composer.json files by using a CURRENT_CMS_MAJOR constant

Both of these commits match what we do in [module-standardiser](https://github.com/silverstripe/module-standardiser/blob/main/funcs_utils.php#L360)