### PR TITLE
FIX Add conditional before adding

### DIFF
--- a/funcs.php
+++ b/funcs.php
@@ -60,7 +60,9 @@ function branches(
     }
     if (!$version) {
         $version = preg_replace('#[^0-9\.]#', '', $json->require->{'silverstripe/assets'} ?? '');
-        $matchedOnBranchThreeLess = true;
+        if ($version) {
+            $matchedOnBranchThreeLess = true;
+        }
     }
     if (!$version) {
         $version = preg_replace('#[^0-9\.]#', '', $json->require->{'cwp/starter-theme'} ?? '');

--- a/tests/BranchesTest.php
+++ b/tests/BranchesTest.php
@@ -357,6 +357,10 @@ class BranchesTest extends TestCase
                 EOT,
                 'branchesJson' => <<<EOT
                 [
+                    {"name": "1"},
+                    {"name": "1.0"},
+                    {"name": "2"},
+                    {"name": "2.0"},
                     {"name": "3"},
                     {"name": "3.0"},
                     {"name": "3.1"},


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/103

Was causing cwp/watea-theme to try and merge up far too many branches

Conditional already exists in the module-standardiser version of this - https://github.com/silverstripe/module-standardiser/blob/main/funcs_utils.php#L355