### PR TITLE
ENH Allow require-dev changes in composer.json

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -124,14 +124,51 @@ runs:
           FILES=$(jq -r .files[].filename __compare.json)
           rm __compare.json
           
-          # Don't allow merge-ups when there are changes in dependency files
-          DEPENDENCY_FILES="composer.json package.json yarn.lock"
+          # Don't allow merge-ups when there are changes in javascript dependency files
+          DEPENDENCY_FILES="package.json yarn.lock"
           for DEPENDENCY_FILE in $DEPENDENCY_FILES; do
             if [[ $(echo "$FILES" | grep $DEPENDENCY_FILE) != "" ]]; then
-              echo "Unable to mergeup between $FROM_BRANCH and $INTO_BRANCH - there are changes in $DEPENDENCY_FILE"
+              echo "Unable to mergeup $FROM_BRANCH into $INTO_BRANCH - there are changes in $DEPENDENCY_FILE"
               exit 1
             fi
           done
+
+          # Don't allow merge-ups where the are changes composer.json, unless the only changes are in "require-dev"
+          if [[ $(echo "$FILES" | grep composer.json) != "" ]]; then
+            RESP_CODE=$(curl -w %{http_code} -s -o __composer_from.json https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$FROM_BRANCH/composer.json)
+            if [[ $RESP_CODE != 200 ]]; then
+              echo "Unable to download composer.json for branch $FROM_BRANCH - HTTP response code was $RESP_CODE"
+              exit 1
+            fi
+            RESP_CODE=$(curl -w %{http_code} -s -o __composer_into.json https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$INTO_BRANCH/composer.json)
+            if [[ $RESP_CODE != 200 ]]; then
+              echo "Unable to download composer.json for branch $INTO_BRANCH - HTTP response code was $RESP_CODE"
+              exit 1
+            fi
+            CAN_MERGE_UP_COMPOSER_JSON=$(php -r '
+              $from = json_decode(file_get_contents("__composer_from.json"), true);
+              $into = json_decode(file_get_contents("__composer_into.json"), true);
+              if (!$from) {
+                throw new Exception("Could not parse __composer_from.json - " . json_last_error_msg());
+              }
+              if (!$into) {
+                throw new Exception("Could not parse __composer_into.json - " . json_last_error_msg());
+              }
+              if (array_key_exists("require-dev", $from)) {
+                unset($from["require-dev"]);
+              }
+              if (array_key_exists("require-dev", $into)) {
+                unset($into["require-dev"]);
+              }
+              echo json_encode($from) === json_encode($into) ? "1" : "0";
+            ')
+            rm __composer_from.json
+            rm __composer_into.json
+            if [[ $CAN_MERGE_UP_COMPOSER_JSON == "0" ]]; then
+              echo "Unable to mergeup $FROM_BRANCH into $INTO_BRANCH - there are non require-dev changes in composer.json"
+              exit 1
+            fi
+          fi
         done
 
     # actions/checkout with fetch-depth: 0 will fetch ALL git history for the repository


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-merge-up/issues/25

This solution differs from the AC's on the issue, though it solves the main reason for creating the issue in the first place

The use of the tripe-dot compare github api endpoint is still correct because even if the commits don't contain any real changes (because equivalent changes were already added to the base branch, which happened with module standardiser), we still need to merge-up those "no changes" commits at some point.  

The reason this was issue was created (as best I understand) is because it simply said there was a bunch of merge conflicts on the phpunit ^9.5 to ^9.6 which was updated independently both the next-patch and next-minor branches, so it was a "no changes" commit, though because it was composer.json gha-merge-up halted.

Example of this allowing composer.json require-dev
- https://github.com/emteknetnz/silverstripe-tagfield/actions/runs/6020600871/job/16332170741
- result https://github.com/emteknetnz/silverstripe-tagfield/commit/ceceba86dcba12b1d4e27d86afe9e7c58572413c

Example of this blocking composer.json require
- https://github.com/emteknetnz/silverstripe-tagfield/actions/runs/6020608658/job/16332188916
- commit it tried to merge-up https://github.com/emteknetnz/silverstripe-tagfield/commit/43e9585a4b6274b83df22c58df3617d86cf00729

