### PR TITLE
FIX Handle linkfield 3.0 branch

### DIFF
--- a/funcs.php
+++ b/funcs.php
@@ -164,7 +164,7 @@ function branches(
     if (isset(DO_NOT_MERGE_UP_FROM_MAJOR[$githubRepository])) {
         $doNotMergeUpFromMajor = DO_NOT_MERGE_UP_FROM_MAJOR[$githubRepository];
         $branches = array_filter($branches, function($branch) use ($doNotMergeUpFromMajor) {
-            return version_compare($branch, $doNotMergeUpFromMajor, '>');
+            return version_compare($branch, "$doNotMergeUpFromMajor.999999.999999", '>');
         });
     }
 

--- a/tests/BranchesTest.php
+++ b/tests/BranchesTest.php
@@ -452,6 +452,9 @@ class BranchesTest extends TestCase
                     {"name": "1"},
                     {"name": "2"},
                     {"name": "3"},
+                    {"name": "3.0"},
+                    {"name": "3.1"},
+                    {"name": "3.999"},
                     {"name": "4"},
                     {"name": "4.0"},
                     {"name": "5"}


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/219

Linkfield 3.0 branch did not exist when the patch for not merge up linkfield v3 originally went in. Since then I created a 3.0 branch when I did the 3.0.0 stable tag

