### PR TITLE
FIX Output branches when there are too many so we can debug

### DIFF
--- a/funcs.php
+++ b/funcs.php
@@ -32,7 +32,8 @@ function branches(
     $branches = BranchLogic::getBranchesForMergeUp($githubRepository, $repoMetaData, $defaultBranch, $allRepoTags, $allRepoBranches, $composerJson);
     // max of 6 branches - also update action.yml if you need to increase this limit
     if (count($branches) > 6) {
-        throw new Exception('More than 6 branches to merge up. Aborting.');
+        $branchesString = implode(', ', $branches);
+        throw new Exception("More than 6 branches to merge up: $branchesString. Aborting.");
     }
     return $branches;
 }


### PR DESCRIPTION
Fluent has too many branches to be merged up, but we don't know which ones: https://github.com/tractorcow-farm/silverstripe-fluent/actions/runs/9166948968/job/25203304664

It's not what the unit tests say should be happening... knowing which branches it things should be there will help identify the problem.

## Issue
- https://github.com/silverstripe/.github/issues/251