### PR TITLE
FIX Allow 7 branches for merge-ups

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -207,9 +207,9 @@ runs:
         git config --local user.name "github-actions"
 
         # List of branches to trigger-ci for later
-        # Normally we'll only ever trigger 3 branches, though providing up to 6 for scenarios
+        # Normally we'll only ever trigger 3 branches, though providing up to 7 for scenarios
         # where there is are things like betas in the mix
-        # branches.php will throw an Exception early if there is more than 6 branches which will cause
+        # branches.php will throw an Exception early if there is more than 7 branches which will cause
         # this job to fail without any merge-ups being performed
         TRIGGER_CI_BRANCH_01=""
         TRIGGER_CI_BRANCH_02=""
@@ -217,6 +217,7 @@ runs:
         TRIGGER_CI_BRANCH_04=""
         TRIGGER_CI_BRANCH_05=""
         TRIGGER_CI_BRANCH_06=""
+        TRIGGER_CI_BRANCH_07=""
         TRIGGER_CI_EXCEEDED=""
 
         FROM_BRANCH=""
@@ -414,6 +415,8 @@ runs:
             TRIGGER_CI_BRANCH_05=$INTO_BRANCH
           elif [[$TRIGGER_CI_BRANCH_06 == "" ]]; then
             TRIGGER_CI_BRANCH_06=$INTO_BRANCH
+          elif [[$TRIGGER_CI_BRANCH_07 == "" ]]; then
+            TRIGGER_CI_BRANCH_07=$INTO_BRANCH
           else
             if [[ $TRIGGER_CI_EXCEEDED == "" ]]; then
               TRIGGER_CI_EXCEEDED=$INTO_BRANCH
@@ -428,6 +431,7 @@ runs:
         echo "TRIGGER_CI_BRANCH_04 is $TRIGGER_CI_BRANCH_04"
         echo "TRIGGER_CI_BRANCH_05 is $TRIGGER_CI_BRANCH_05"
         echo "TRIGGER_CI_BRANCH_06 is $TRIGGER_CI_BRANCH_06"
+        echo "TRIGGER_CI_BRANCH_07 is $TRIGGER_CI_BRANCH_07"
         echo "TRIGGER_CI_EXCEEDED is $TRIGGER_CI_EXCEEDED"
         echo "trigger_ci_branch_01=$TRIGGER_CI_BRANCH_01" >> $GITHUB_OUTPUT
         echo "trigger_ci_branch_02=$TRIGGER_CI_BRANCH_02" >> $GITHUB_OUTPUT
@@ -435,6 +439,7 @@ runs:
         echo "trigger_ci_branch_04=$TRIGGER_CI_BRANCH_04" >> $GITHUB_OUTPUT
         echo "trigger_ci_branch_05=$TRIGGER_CI_BRANCH_05" >> $GITHUB_OUTPUT
         echo "trigger_ci_branch_06=$TRIGGER_CI_BRANCH_06" >> $GITHUB_OUTPUT
+        echo "trigger_ci_branch_07=$TRIGGER_CI_BRANCH_07" >> $GITHUB_OUTPUT
         echo "trigger_ci_exceeded=$TRIGGER_CI_EXCEEDED" >> $GITHUB_OUTPUT
 
     - name: Trigger CI 01
@@ -472,6 +477,12 @@ runs:
       uses: silverstripe/gha-trigger-ci@v1
       with:
         branch: ${{ steps.git-merge-up.outputs.trigger_ci_branch_06 }}
+
+    - name: Trigger CI 07
+      if: ${{ steps.git-merge-up.outputs.trigger_ci_branch_07 != '' }}
+      uses: silverstripe/gha-trigger-ci@v1
+      with:
+        branch: ${{ steps.git-merge-up.outputs.trigger_ci_branch_07 }}
 
     - name: Trigger CI Exceeded
       if: ${{ steps.git-merge-up.outputs.trigger_ci_exceeded != '' }}

--- a/funcs.php
+++ b/funcs.php
@@ -30,10 +30,10 @@ function branches(
     $allRepoBranches = array_map(fn($x) => $x->name, json_decode(file_get_contents('__branches.json')));
 
     $branches = BranchLogic::getBranchesForMergeUp($githubRepository, $repoMetaData, $defaultBranch, $allRepoTags, $allRepoBranches, $composerJson);
-    // max of 6 branches - also update action.yml if you need to increase this limit
-    if (count($branches) > 6) {
+    // max of 7 branches - also update action.yml if you need to increase this limit
+    if (count($branches) > 7) {
         $branchesString = implode(', ', $branches);
-        throw new Exception("More than 6 branches to merge up: $branchesString. Aborting.");
+        throw new Exception("More than 7 branches to merge up: $branchesString. Aborting.");
     }
     return $branches;
 }

--- a/tests/BranchesTest.php
+++ b/tests/BranchesTest.php
@@ -88,7 +88,54 @@ class BranchesTest extends TestCase
                 ]
                 EOT,
             ],
-            'More than 6 branches exception' => [
+            '6.0.0-alpha1 with all final CMS 4/5 branches on silverstripe/framework' => [
+                'expected' => ['4.13', '4', '5.3', '5.4', '5', '6.0', '6'],
+                'defaultBranch' => '5',
+                'githubRepository' => 'lorem/ipsum',
+                'composerJson' => <<<EOT
+                {
+                    "require": {
+                        "silverstripe/framework": "^5.4"
+                    }
+                }
+                EOT,
+                'branchesJson' => <<<EOT
+                [
+                    {"name": "3"},
+                    {"name": "3.6"},
+                    {"name": "3.7"},
+                    {"name": "4"},
+                    {"name": "4.10"},
+                    {"name": "4.11"},
+                    {"name": "4.12"},
+                    {"name": "4.13"},
+                    {"name": "5"},
+                    {"name": "5.0"},
+                    {"name": "5.1"},
+                    {"name": "5.2"},
+                    {"name": "5.3"},
+                    {"name": "5.4"},
+                    {"name": "6"},
+                    {"name": "6.0"}
+                ]
+                EOT,
+                'tagsJson' => <<<EOT
+                [
+                    {"name": "6.0.0-alpha1"},
+                    {"name": "5.4.0-beta1"},
+                    {"name": "5.3.0"},
+                    {"name": "5.2.0"},
+                    {"name": "5.1.0"},
+                    {"name": "5.0.9"},
+                    {"name": "4.13.11"},
+                    {"name": "4.12.11"},
+                    {"name": "4.11.11"},
+                    {"name": "4.10.11"},
+                    {"name": "3.7.4"}
+                ]
+                EOT,
+            ],
+            'More than 7 branches exception' => [
                 'expected' => ['__exception__'],
                 'defaultBranch' => '5',
                 'githubRepository' => 'lorem/ipsum',
@@ -113,11 +160,13 @@ class BranchesTest extends TestCase
                     {"name": "5.0"},
                     {"name": "5.1"},
                     {"name": "5.2"},
-                    {"name": "6"}
+                    {"name": "6"},
+                    {"name": "6.0"}
                 ]
                 EOT,
                 'tagsJson' => <<<EOT
                 [
+                    {"name": "6.0.0-alpha1"},
                     {"name": "5.2.0-beta1"},
                     {"name": "5.1.0-beta1"},
                     {"name": "5.0.9"},


### PR DESCRIPTION
This will resolve it for most things - might also fix it for framework, as the unit test indicates it should only be outputting 6 items.
After merging, reassign to me to double check framework is happy.

## Issue
- https://github.com/silverstripe/gha-merge-up/issues/49