### PR TITLE
FIX Use up to 200 tags for merge-up branch identification

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
         fi
 
         # Gets 100 most recently created tags from GitHub API
-        # https://docs.github.com/en/rest/git/tags?apiVersion=2022-11-28
+        # https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
         RESP_CODE=$(curl -w %{http_code} -s -o __tags.json \
         -X GET "https://api.github.com/repos/$GITHUB_REPOSITORY/tags?per_page=100" \
         -H "Accept: application/vnd.github+json" \
@@ -82,6 +82,25 @@ runs:
         )
         if [[ $RESP_CODE != "200" ]]; then
           echo "Unable to read list of tags - HTTP response code was $RESP_CODE"
+          exit 1
+        fi
+        # Parse the "link" header to see if there's a next page of tags
+        NEXT_LINK=$(curl -I -s \
+        -X HEAD "https://api.github.com/repos/$GITHUB_REPOSITORY/tags?per_page=100" \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${{ github.token }}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        | sed -n -E 's/link:.*<(.*?)>; rel="next".*/\1/p'
+        )
+        # Get the next 100 tags just in case (sometimes needed at the end of a major release line cycle)
+        RESP_CODE=$(curl -w %{http_code} -s -o __tags2.json \
+        -X GET "${NEXT_LINK}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${{ github.token }}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        )
+        if [[ $RESP_CODE != "200" ]]; then
+          echo "Unable to read second page of tags - HTTP response code was $RESP_CODE"
           exit 1
         fi
 
@@ -104,6 +123,9 @@ runs:
         fi
         echo "branches=$BRANCHES" >> $GITHUB_OUTPUT
         rm __tags.json
+        if [[ -f __tags2.json ]]; then
+          rm __tags2.json
+        fi
         rm __branches.json
         if [[ -f __composer.json ]]; then
           rm __composer.json

--- a/funcs.php
+++ b/funcs.php
@@ -27,6 +27,9 @@ function branches(
 
     $repoMetaData = MetaData::getMetaDataForRepository($githubRepository);
     $allRepoTags = array_map(fn($x) => $x->name, json_decode(file_get_contents('__tags.json')));
+    if (file_exists('__tags2.json')) {
+        $allRepoTags = array_merge($allRepoTags, array_map(fn($x) => $x->name, json_decode(file_get_contents('__tags2.json'))));
+    }
     $allRepoBranches = array_map(fn($x) => $x->name, json_decode(file_get_contents('__branches.json')));
 
     $branches = BranchLogic::getBranchesForMergeUp($githubRepository, $repoMetaData, $defaultBranch, $allRepoTags, $allRepoBranches, $composerJson);


### PR DESCRIPTION
Turns out we weren't getting any of the CMS 4 tags for framework, because there's > 100 tags for CMS 5!
Getting a second page of 100 tags should be good enough. Might need to revisit if our team doubles in size and bug patch output increases.

## Issue
- https://github.com/silverstripe/gha-merge-up/issues/49