### PR TITLE
NEW Halt the merge-up if deprecated code is detected

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -254,6 +254,19 @@ runs:
           fi
           echo "Attempting to merge-up $FROM_BRANCH into $INTO_BRANCH"
 
+          # Determine if this is a major merge-up (e.g. from 4 to 5.0)
+          IS_MAJOR_MERGE=0
+          [[ $FROM_BRANCH =~ ^([0-9]+)(\..+)?$ ]]
+          FROM_MAJOR=${BASH_REMATCH[1]}
+          [[ $INTO_BRANCH =~ ^([0-9]+)(\..+)?$ ]]
+          INTO_MAJOR=${BASH_REMATCH[1]}
+          MERGE_UP_TYPE="minor"
+          if [[ $FROM_MAJOR != $INTO_MAJOR ]]; then
+            IS_MAJOR_MERGE=1
+            MERGE_UP_TYPE="major"
+          fi
+          echo "This is a $MERGE_UP_TYPE merge-up from $FROM_BRANCH (major $FROM_MAJOR) to $INTO_BRANCH (major $INTO_MAJOR)"
+
           # Checkout both branches to ensure branch info is up to date
           # Also runs `git pull` which should not be necessary, though in practice GitHub actions sometimes
           # rejects when pushing saying the tip of the branch is out of date. This possibly only happens
@@ -299,6 +312,22 @@ runs:
             # The following line needs to be quoted so that line breaks show
             echo "$UNMERGED_FILES"
             exit 1
+          fi
+
+          # Check for deprecated code in php files and halt the merge-up if it is between majors and
+          # any deprecated code is found
+          if [[ $IS_MAJOR_MERGE == 1 ]]; then
+            DEPRECATED_CODE=$( \
+              git diff --cached --name-only \
+              | grep .php \
+              | xargs grep --with-filename --line-number --color=always \
+                --extended-regexp 'SilverStripe\\Dev\\Deprecation|Deprecation::|@deprecated' \
+            )
+            if [[ $DEPRECATED_CODE != "" ]]; then
+              echo "Deprecated code detected. Resolve this before merging-up $FROM_BRANCH into $INTO_BRANCH. Aborting."
+              echo "$DEPRECATED_CODE"
+              exit 1
+            fi
           fi
 
           # Rebuild client/dist if needed


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-merge-up/issues/55

Create 2.1 branch and tag 2.1.0 after merge

Can test this locally:

```bash
# --- 1. Set up a new temporary git repository ---
if [ -d test-repo ]; then rm -rf test-repo; fi
mkdir test-repo
cd test-repo
git init
echo "This is a new project." > README.md
echo "This contains a string that will merge up" > something.md
echo "This is some code that will later fail" > code-a.php
echo "This is some code that will later fail" > code-b.php
echo "This is some code that will later fail" > code-c.php
# echo "This is some code that will pass through" > Deprecation.php
git add .
git commit -m "Initial commit"

# --- 2. Create a simulrated previous branch and add deprecated code ---
FROM_BRANCH=main
INTO_BRANCH=prev-branch
git checkout -b $INTO_BRANCH
echo "This should merge-up with no issues" >> README.md
echo "@deprecated ok - this will be allowed to merge-up" > something.md
echo "import SilverStripe\Dev\Deprecation; - this will fail the merge-up" >> code-a.php
echo "Deprecation::notice() - this will fail the merge-up" >> code-b.php
echo "@deprecated thing - this will fail the merge-up" >> code-c.php
# echo "@deprecated ok - this will be allowed to merge-up" >> Deprecation.php
git add .
git commit -m "Add deprecated code"

# --- 3. Return to the main branch and simulate the merge- up---
git checkout main
git merge --no-ff --no-commit prev-branch

# --- 4. Run PR code (with exit 1 commented out) ---
DEPRECATED_CODE=$( \
  git diff --cached --name-only \
  | grep .php \
  | xargs grep --with-filename --line-number --color=always \
    --extended-regexp 'SilverStripe\\Dev\\Deprecation|Deprecation::|@deprecated' \
)
if [[ $DEPRECATED_CODE != "" ]]; then
  echo "Deprecated code detected. Resolve this before merging-up $FROM_BRANCH into $INTO_BRANCH. Aborting."
  echo "$DEPRECATED_CODE"
  # exit 1
fi

# --- 5. Clean up the test repository ---
cd ..
rm -rf test-repo
```