### PR TITLE
ENH Allow changes in yarn.lock on merge-up

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -163,9 +163,8 @@ runs:
           rm __compare.json
 
           # Don't allow merge-ups when there are changes in javascript dependency files (e.g. package.json)
-          # Note that yarn.lock is allowed to merge-up between minors only (not majors)
-          # Its presence in a git diff will force a yarn build (assuming no merge-conflicts)
-          # There is a check in a later step if it's a minor or major merge-up
+          # Note that yarn.lock is allowed to merge-up between minors and majors. Its presence in a git diff
+          # will force a yarn install and yarn build which will correctly resolve JS deps
           DEPENDENCY_FILES="package.json"
           for DEPENDENCY_FILE in $DEPENDENCY_FILES; do
             if [[ $(echo "$FILES" | grep $DEPENDENCY_FILE) != "" ]]; then
@@ -292,7 +291,7 @@ runs:
           # Determine if we will rebuild dist file during merge-up
           # This is based on:
           # - if there are changes in the client/ directory and if there's a package.json file, OR
-          # - if there are changes in yarn.lock, though this is only allowed for minor-merge-ups
+          # - if there are changes in yarn.lock
           REBUILD=0
           CLIENT_DIFF_FILES=$(git diff --name-only $INTO_BRANCH...$FROM_BRANCH | grep -P ^client/) || true
           echo "CLIENT_DIFF_FILES is:"
@@ -304,13 +303,7 @@ runs:
           YARN_LOCK_DIFF=$(git diff --name-only $INTO_BRANCH...$FROM_BRANCH | grep -P ^yarn\.lock$) || true
           echo "YARN_LOCK_DIFF is $YARN_LOCK_DIFF"
           if [[ $YARN_LOCK_DIFF != "" ]]; then
-            if [[ $MERGE_UP_TYPE == "major" ]]; then
-              echo "Changes in yarn.lock detected when doing major merge up from $FROM_BRANCH into $INTO_BRANCH. Aborting."
-              exit 1
-            else
-              # Minor merge-up allows changes in yarn.lock, though there needs to be a rebuild
-              REBUILD=1
-            fi
+            REBUILD=1
           fi
           echo "REBUILD is $REBUILD"
 
@@ -320,9 +313,9 @@ runs:
           # We often expect a merge-conflict when there are client/dist file differences
           MERGE_RESULT=$(git merge --no-ff --no-commit $FROM_BRANCH || true)
 
-          # Only merge conflicts in client/dist are allowed, stop for all others, including yarn.lock
+          # Only merge conflicts in client/dist and yarn.lock are allowed, stop for all others
           # See https://git-scm.com/docs/git-status#_output for information on the porcelain format
-          UNMERGED_FILES=$(git status --porcelain=v1 | grep -P '^(DD|AU|UD|UA|DU|AA|UU)' | grep -v client/dist) || true
+          UNMERGED_FILES=$(git status --porcelain=v1 | grep -P '^(DD|AU|UD|UA|DU|AA|UU)' | grep -v client/dist | grep -v yarn.lock) || true
           if [[ $UNMERGED_FILES != "" ]]; then
             echo "Merge conflict found when merging-up $FROM_BRANCH into $INTO_BRANCH. Aborting."
             # The following line needs to be quoted so that line breaks show
@@ -432,6 +425,9 @@ runs:
             fi
 
             # Rebuild dist files.
+            # `yarn install` will handle any merge conflicts in `yarn.lock`
+            # It will effectively do a JS Deps upgrade as part of the merge-up and use the
+            # most recent versions of deps allowable by package.json
             # Note that `yarn install` probably isn't required as the `build` script in package.json
             # for every module should include `yarn &&` which will do `yarn install`, though we include
             # it here just to be extra sure


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-merge-up/issues/62

`yarn install` is clever and will resolve merge conflicts ... though it will effectively be doing a JS upgrade whenever we do this. This is the correct way to handle this though. The others way to handle this would be:
- revert any changes in yarn.lock on merge-up, meaning that updated deps don't bubble up, which is inconsistent with everything else we merge-up
- manually select --ours or --theirs in the resulting merge conflict ... but then you risk yarn.lock being invalid, and the actual JS isn't updated